### PR TITLE
Fix selecting the default variation

### DIFF
--- a/src/components/forms/AddToCart.tsx
+++ b/src/components/forms/AddToCart.tsx
@@ -1,5 +1,5 @@
 import { Product, Variation, VariationType } from '@/types/product.types'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import toast, { Toaster } from 'react-hot-toast'
 
 import { QuantityStepper } from '@/components/app/Product/QuantityStepper'
@@ -12,16 +12,38 @@ type ProductVariationType = VariationType & {
 }
 
 export const AddToCart = ({ product }: { product: Product }) => {
-  const [typesState, setTypesState] = useState<Array<ProductVariationType>>(
-    product.variationTypes.map((t) => ({
-      ...t,
-      selectedVariation: t.variations[0],
-    }))
-  )
+  const [typesState, setTypesState] = useState<Array<ProductVariationType>>([])
 
   const [quantity, setQuantity] = useState(1)
 
   const { setCart } = useCartContext()
+
+  /**
+   * Select the first variation of the children of each type (first render only)
+   */
+  useEffect(() => {
+    const newTypeStates: Array<ProductVariationType> = []
+
+    product.variationTypes.forEach((t, index) => {
+      const previousType = newTypeStates[index - 1]
+
+      /**
+       * getting only the variations that is feasible on the screen
+       * if they are the first level with no parent then we expect to see them all in the screen
+       * also if there parent is selected then we expect to see them
+       */
+      const childVariations = t.variations.filter(
+        (v) => !v.parentId || previousType?.selectedVariation?.id === v.parentId
+      )
+
+      /**
+       * Select the first variation of the children (for this type)
+       */
+      newTypeStates.push({ ...t, selectedVariation: childVariations[0] })
+    })
+
+    setTypesState(newTypeStates)
+  }, [product])
 
   const changeSelectedVariation = (
     variation: Variation,
@@ -50,7 +72,7 @@ export const AddToCart = ({ product }: { product: Product }) => {
         }
       })
 
-      return [...newTypes]
+      return newTypes
     })
   }
 
@@ -78,13 +100,13 @@ export const AddToCart = ({ product }: { product: Product }) => {
           .then((data) => setCart(data))
           .catch(console.log)
       )
-      .catch(console.error);
+      .catch(console.error)
   }
 
   return (
     <form className="mt-10" onSubmit={(e) => e.preventDefault()}>
       <Toaster />
-      {/* Sizes */}
+      
       {typesState.map((t, index) => {
         const previousType = typesState[index - 1]
         const childVariations = t.variations.filter(
@@ -102,10 +124,12 @@ export const AddToCart = ({ product }: { product: Product }) => {
           </div>
         )
       })}
+
       <div className="mt-10">
         <h3 className="mb-4 text-sm font-medium text-gray-900">quantity</h3>
         <QuantityStepper initial={quantity} onChange={handleQuantityChange} />
       </div>
+
       <button
         onClick={addToCart}
         type="submit"

--- a/src/components/forms/AddToCart.tsx
+++ b/src/components/forms/AddToCart.tsx
@@ -24,7 +24,7 @@ export const AddToCart = ({ product }: { product: Product }) => {
   useEffect(() => {
     const newTypeStates: Array<ProductVariationType> = []
 
-    product.variationTypes.forEach((t, index) => {
+    product.variationTypes.forEach((variationType, index) => {
       const previousType = newTypeStates[index - 1]
 
       /**
@@ -32,14 +32,14 @@ export const AddToCart = ({ product }: { product: Product }) => {
        * if they are the first level with no parent then we expect to see them all in the screen
        * also if there parent is selected then we expect to see them
        */
-      const childVariations = t.variations.filter(
-        (v) => !v.parentId || previousType?.selectedVariation?.id === v.parentId
+      const childVariations = variationType.variations.filter(
+        variation => !variation.parentId || previousType?.selectedVariation?.id === variation.parentId
       )
 
       /**
        * Select the first variation of the children (for this type)
        */
-      newTypeStates.push({ ...t, selectedVariation: childVariations[0] })
+      newTypeStates.push({ ...variationType, selectedVariation: childVariations[0] })
     })
 
     setTypesState(newTypeStates)


### PR DESCRIPTION
***What***
Fix selecting the default variation

***Why***
We were selecting the first variation of a given type in the first load, but this produced the bug in the first screenshot below. 
We may choose a variation as a default selection, but this variation is not feasible on the screen

***Fix***
Now we select the first variation of a type but make sure it is feasible on the screen

***Screenshots***

- The bug
![bug1](https://github.com/ecommerce-cart/frontend/assets/33164530/4ff62300-5f48-4851-9455-eb0a3f8ae76c)
- The fix
![image](https://github.com/ecommerce-cart/frontend/assets/33164530/c94ccca3-b39f-4007-b905-00de10bfc07d)

***Links***
[Trello Task
](https://trello.com/c/MSaL9Jcb/9-it-happens-randomly-that-the-last-variation-is-not-selected-by-default)